### PR TITLE
Escape search value colons

### DIFF
--- a/recipes/discovery.rb
+++ b/recipes/discovery.rb
@@ -7,7 +7,7 @@ discover_query += Array(node[:zookeeperd][:cluster][:discovery_query]).flatten.c
 
 # ensure that colons in search query values are escaped
 # but leave first colon intact as query delimeter
-discover_query.map do |i|
+discover_query = discover_query.map do |i|
   item = i.split(":", 2)
   key = item[0]
   value = item[1].gsub(":", '\:')


### PR DESCRIPTION
When `zookeeperd.cluster.discovery_query` contains a string with one or more colons (i.e. AWS CloudFormation stack ID), the subsequent Chef search query will fail with a bad request. This change attempts to escape colons inside of values while leaving the colon delimiters between keys and their values intact.
