### PR TITLE
Allow for control of platform_version attribute for other distros like Amazon Linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-defatul[:zookeeperd][:install][:platform_version] = node[:platform_version]
+default[:zookeeperd][:install][:platform_version] = node[:platform_version]
 
 if(node.platform_family?('rhel', 'fedora', 'suse'))
   default[:zookeeperd][:server_packages] = %w(zookeeper-server)


### PR DESCRIPTION
@chrisroberts
